### PR TITLE
Add environment configuration for Ember application

### DIFF
--- a/client/config/environment.js
+++ b/client/config/environment.js
@@ -21,7 +21,7 @@ module.exports = function (environment) {
       // Here you can pass flags/options to your application instance
       // when it is created
     },
-    PROXY_URL: process.env.PROXY_URL,
+    PROXY_URL: process.env.BACKEND_URL,
   };
 
   if (environment === 'development') {


### PR DESCRIPTION
- Set up environment-specific settings in `client/config/environment.js`
- Configure `PROXY_URL` to use `process.env.BACKEND_URL`